### PR TITLE
Add JRuby support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.o
 *.a
 mkmf.log
+lib/binding_ninja/binding_ninja.jar
 
 # rspec failure tracking
 .rspec_status

--- a/Rakefile
+++ b/Rakefile
@@ -3,12 +3,19 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-require "rake/extensiontask"
-
 task :build => :compile
 
-Rake::ExtensionTask.new("binding_ninja") do |ext|
-  ext.lib_dir = "lib/binding_ninja"
+case RUBY_PLATFORM
+when /java/
+  require 'rake/javaextensiontask'
+  Rake::JavaExtensionTask.new('binding_ninja') do |ext|
+    ext.lib_dir = "lib/binding_ninja"
+  end
+else
+  require 'rake/extensiontask'
+  Rake::ExtensionTask.new("binding_ninja") do |ext|
+    ext.lib_dir = "lib/binding_ninja"
+  end
 end
 
 task :default => [:clobber, :compile, :spec]

--- a/binding_ninja.gemspec
+++ b/binding_ninja.gemspec
@@ -20,7 +20,14 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.extensions    = ["ext/binding_ninja/extconf.rb"]
+
+  case RUBY_PLATFORM
+  when /java/
+    spec.platform = "java"
+    spec.files << "lib/binding_ninja/binding_ninja.jar"
+  else
+    spec.extensions = ["ext/binding_ninja/extconf.rb"]
+  end
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/ext/binding_ninja/BindingNinjaService.java
+++ b/ext/binding_ninja/BindingNinjaService.java
@@ -1,0 +1,18 @@
+package io.github.joker1007;
+
+import java.io.IOException;
+
+import org.jruby.Ruby;
+import org.jruby.RubyHash;
+import org.jruby.RubyModule;
+import org.jruby.runtime.load.BasicLibraryService;
+
+public class BindingNinjaService implements BasicLibraryService {
+  @Override
+  public boolean basicLoad(final Ruby runtime) throws IOException {
+    RubyModule bindingNinja = runtime.defineModule("BindingNinja");
+    bindingNinja.setInstanceVariable("@auto_inject_binding_extensions", RubyHash.newHash(runtime));
+    bindingNinja.defineAnnotatedMethods(RubyBindingNinja.class);
+    return true;
+  }
+}

--- a/ext/binding_ninja/RubyBindingNinja.java
+++ b/ext/binding_ninja/RubyBindingNinja.java
@@ -1,0 +1,139 @@
+package io.github.joker1007;
+
+import org.jruby.anno.JRubyMethod;
+import org.jruby.anno.JRubyModule;
+import org.jruby.ast.util.ArgsUtil;
+import org.jruby.internal.runtime.methods.JavaMethod;
+import org.jruby.Ruby;
+import org.jruby.RubyBasicObject;
+import org.jruby.RubyBinding;
+import org.jruby.RubyClass;
+import org.jruby.RubyHash;
+import org.jruby.RubyMethod;
+import org.jruby.RubyModule;
+import org.jruby.RubyProc;
+import org.jruby.RubySymbol;
+import org.jruby.runtime.Block;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.runtime.Helpers;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.Visibility;
+
+@JRubyModule(name = "BindingNinja")
+public class RubyBindingNinja {
+  static String OPTIONS_ID = "@auto_inject_binding_options";
+  static String EXTENSIONS_ID = "@auto_inject_binding_extensions";
+
+  @JRubyMethod(name = "auto_inject_binding", module = true, visibility = Visibility.PRIVATE, required = 1, optional = 1)
+  public static IRubyObject autoInjectBinding(ThreadContext context, IRubyObject recv, IRubyObject[] args) {
+    final Ruby runtime = context.getRuntime();
+
+    final IRubyObject extensions = runtime.getModule("BindingNinja").getInstanceVariable(EXTENSIONS_ID);
+    final IRubyObject methodSym = args[0];
+
+    IRubyObject ivar = ((RubyModule)recv).getInstanceVariable(OPTIONS_ID);
+    final IRubyObject options;
+    if (ivar.isTrue()) {
+      options = ivar;
+    } else {
+      options = RubyHash.newHash(runtime);
+      ((RubyModule)recv).setInstanceVariable(OPTIONS_ID, options);
+    }
+
+    IRubyObject extModTmp =
+      extensions instanceof RubyHash ?
+        ((RubyHash)extensions).op_aref(context, recv) :
+        context.nil;
+    if (extModTmp.isNil()) {
+      extModTmp = RubyModule.newModule(runtime);
+      ((RubyHash)extensions).op_aset(context, recv, extModTmp);
+    }
+    final RubyModule extMod = (RubyModule)extModTmp;
+    if (!((RubyModule)recv).hasModuleInHierarchy(extMod)) {
+      ((RubyModule)recv).prependModule(extMod);
+    }
+
+    IRubyObject cond = RubyBasicObject.UNDEF;
+    if (args.length == 2) {
+      final RubyHash kwArgs = args[1].convertToHash();
+      final IRubyObject[] rets = ArgsUtil.extractKeywordArgs(runtime.getCurrentContext(), kwArgs, "if");
+      cond = rets[0];
+    }
+
+    if (cond != RubyBasicObject.UNDEF) {
+      ((RubyHash)options).op_aset(context, methodSym, cond);
+    }
+
+    final String mid = methodSym.asJavaString();
+    if (cond == RubyBasicObject.UNDEF) {
+      extMod.addMethod(mid, autoInjectBindingInvokeWithoutCond(extMod, mid));
+    } else {
+      final RubyClass klass = cond.getMetaClass().getRealClass();
+      if (klass == runtime.getProc() || klass == runtime.getSymbol()) {
+        extMod.addMethod(mid, autoInjectBindingInvoke(extMod, mid));
+      } else if (cond.isTrue()) {
+        extMod.addMethod(mid, autoInjectBindingInvokeWithoutCond(extMod, mid));
+      } else {
+        extMod.addMethod(mid, autoInjectBindingInvokeStub(extMod, mid));
+      }
+    }
+
+    return methodSym;
+  }
+
+  private static JavaMethod autoInjectBindingInvoke(final RubyModule extMod, String name) {
+    return new JavaMethod(extMod, Visibility.PUBLIC, name) {
+      @Override
+      public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args, Block block) {
+        final IRubyObject options = Helpers.invoke(context, clazz, "auto_inject_binding_options");
+        IRubyObject cond = ((org.jruby.RubyHash)options).op_aref(context, RubySymbol.newSymbol(context.getRuntime(), name));
+
+        final RubyClass klass = cond.getMetaClass().getRealClass();
+        if (klass == context.getRuntime().getProc()) {
+          if (Math.abs(((RubyProc)cond).arity().getIntValue()) > 0) {
+            cond = ((RubyProc)cond).call(context, new IRubyObject[]{self});
+          } else {
+            cond = ((RubyProc)cond).call(context, new IRubyObject[]{});
+          }
+        } else if (klass == context.getRuntime().getSymbol()) {
+          final IRubyObject method = ((RubyBasicObject)self).method(cond);
+          final IRubyObject proc = ((RubyMethod) method).to_proc(context);
+          cond = ((RubyProc)proc).call(context, new IRubyObject[]{});
+        }
+
+        final IRubyObject[] unshiftedArgs = new IRubyObject[args.length + 1];
+        if (cond.isTrue()) {
+          unshiftedArgs[0] = RubyBinding.newBinding(context.getRuntime(), context.currentBinding());
+        } else {
+          unshiftedArgs[0] = context.nil;
+        }
+        System.arraycopy(args, 0, unshiftedArgs, 1, args.length);
+        return Helpers.invokeSuper(context, self, extMod, name, unshiftedArgs, block);
+      }
+    };
+  }
+
+  private static JavaMethod autoInjectBindingInvokeStub(final RubyModule extMod, String name) {
+    return new JavaMethod(extMod, Visibility.PUBLIC, name) {
+      @Override
+      public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args, Block block) {
+        final IRubyObject[] unshiftedArgs = new IRubyObject[args.length + 1];
+        unshiftedArgs[0] = context.nil;
+        System.arraycopy(args, 0, unshiftedArgs, 1, args.length);
+        return Helpers.invokeSuper(context, self, extMod, name, unshiftedArgs, block);
+      }
+    };
+  }
+
+  private static JavaMethod autoInjectBindingInvokeWithoutCond(final RubyModule extMod, String name) {
+    return new JavaMethod(extMod, Visibility.PUBLIC, name) {
+      @Override
+      public IRubyObject call(ThreadContext context, IRubyObject self, RubyModule clazz, String name, IRubyObject[] args, Block block) {
+        final IRubyObject[] unshiftedArgs = new IRubyObject[args.length + 1];
+        unshiftedArgs[0] = RubyBinding.newBinding(context.getRuntime(), context.currentBinding());
+        System.arraycopy(args, 0, unshiftedArgs, 1, args.length);
+        return Helpers.invokeSuper(context, self, extMod, name, unshiftedArgs, block);
+      }
+    };
+  }
+}

--- a/lib/binding_ninja.rb
+++ b/lib/binding_ninja.rb
@@ -1,5 +1,11 @@
 require "binding_ninja/version"
-require "binding_ninja/binding_ninja"
+
+if /java/ =~ RUBY_PLATFORM
+  require_relative 'binding_ninja/binding_ninja.jar'
+  Java::IoGithubJoker1007::BindingNinjaService.new.basicLoad(JRuby.runtime)
+else
+  require "binding_ninja/binding_ninja"
+end
 
 module BindingNinja
   def auto_inject_binding_options

--- a/spec/binding_ninja_spec.rb
+++ b/spec/binding_ninja_spec.rb
@@ -105,7 +105,14 @@ RSpec.describe BindingNinja do
     expect(Bar.new.foo6).to be_nil
     expect(Baz.new.foo6).to match_array([:hoge, :obj, :klass])
     expect(klass.new.foo).to match_array([:hoge, :obj, :klass])
-    expect(Foo2.new.foo).to match_array([:hoge, :obj, :klass])
+    case RUBY_PLATFORM
+    when /java/
+      skip 'JRuby refinement support is WIP' do
+        expect(Foo2.new.foo).to match_array([:hoge, :obj, :klass])
+      end
+    else
+      expect(Foo2.new.foo).to match_array([:hoge, :obj, :klass])
+    end
   end
 
   it "create extension module", aggregate_failures: true do


### PR DESCRIPTION
* Tests pass except for one with refinement
    * It's disabled for now

```
$ bundle exec rake compile && bundle _1.15.0_ exec rspec --no-color
install -c tmp/java/binding_ninja/binding_ninja.jar lib/binding_ninja/binding_ninja.jar
The latest bundler is 2.0.1, but you are currently running 1.15.0.
To update, run `gem install bundler`

BindingNinja
  inject binding (PENDING: JRuby refinement support is WIP)
  create extension module

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) BindingNinja inject binding
     # JRuby refinement support is WIP
     # ./spec/binding_ninja_spec.rb:89

Finished in 0.03192 seconds (files took 0.3652 seconds to load)
2 examples, 0 failures, 1 pending
```

* If you run it it fails with Java NPE

```
  1) BindingNinja inject binding
     Failure/Error: Unable to find org.jruby.runtime.Helpers.invokeSuper(Helpers.java to read failed line
     Java::JavaLang::NullPointerException:
     # org.jruby.runtime.Helpers.invokeSuper(Helpers.java:534)
     # io.github.joker1007.RubyBindingNinja$3.call(RubyBindingNinja.java:135)
```