### PR TITLE
Added Support for Linux on Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: ruby
+arch:
+  - amd64
+  - ppc64le
 rvm:
   - 2.5.5
   - 2.6.3


### PR DESCRIPTION

Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/binding_ninja/builds/207311210
Please have a look.

Regards,
ujjwal
